### PR TITLE
Fix error message for missing class external ID

### DIFF
--- a/grade-sync-worker/GradeSync.cs
+++ b/grade-sync-worker/GradeSync.cs
@@ -67,7 +67,7 @@ namespace grade_sync_worker
                 }
                 if (gradeSyncJobEntity.ClassExternalId is null || gradeSyncJobEntity.ClassExternalId == "")
                 {
-                    throw new InvalidOperationException("GradeSyncJobEntity does not exist.");
+                    throw new InvalidOperationException("Teams EDU class does not have an external/SIS ID set. Contact your administrator or run Microsoft SDS to sync your classes.");
                 }
 
                 var connectionEntity = await _storageService.GetOneRosterConnectionEntity(gradeSyncMessage!.TenantId, gradeSyncJobEntity.OneRosterConnectionId);


### PR DESCRIPTION
add error message to reflect when a Teams class is missing an external/SIS ID.